### PR TITLE
Allow C11 when missing uchar.h; allow using uchar32_t in C++11.

### DIFF
--- a/include/utf.h
+++ b/include/utf.h
@@ -5,8 +5,15 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#if __STDC_VERSION__ >= 201112L
+#if __STDC_VERSION__ >= 201112L || __cplusplus >= 201103L
+#if !defined(__cplusplus)
+#if defined(__has_include) && __has_include(<uchar.h>)
 #include <uchar.h>
+#else
+typedef uint_least16_t char16_t;
+typedef uint_least32_t char32_t;
+#endif
+#endif
 #ifdef __STDC_UTF_32__
 #define RUNE_C INT32_C
 typedef char32_t Rune;


### PR DESCRIPTION
Mac OS X doesn't have uchar.h, but otherwise supports C11. I don't really know why. The C11 standard defines char32_t as identical to uint_least32_t. In C++11, it char32_t is a fundamental type, not a macro.

This workaround is pull more or less verbatim from what [Apple does in this case themselves](https://github.com/auth0/Auth0.swift/blob/master/Carthage/Build/Mac/JWTDecode.framework/Versions/A/Headers/JWTDecode-Swift.h#L14).